### PR TITLE
Add new income proof variables

### DIFF
--- a/usecases/src/main/resources/data_packages.yaml
+++ b/usecases/src/main/resources/data_packages.yaml
@@ -16,6 +16,9 @@ dataPackages:
       - statusKey: GBCONNECT.FINANCIAL.VARIABLES.STATUS
         eventName: gbconnect:financial:variables
         eventVersion: 1
+      - statusKey: GBCONNECT.INCOME.PROOF.STATUS
+        eventName: gbconnect:income:proof:variables
+        eventVersion: 1
 
 dataCaches:
   - eventName: gbconnect:variables


### PR DESCRIPTION
# What?
Add new event `gbconnect:income:proof:variables` to data_packages.yaml.